### PR TITLE
Remove the empty constructor

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -51,5 +51,6 @@ jobs:
       run: |
         cabal v2-configure pkg:persistent-vector --enable-tests
         cabal v2-build pkg:persistent-vector
-        cabal v2-test pkg:persistent-vector
-
+        cabal v2-test pkg:persistent-vector --test-options="-a 10000"
+        cabal v2-test pkg:persistent-vector --test-options="-s 10000"
+        cabal v2-test pkg:persistent-vector --test-options="-a 1000 -s 1000"

--- a/src/Data/Vector/Persistent.hs
+++ b/src/Data/Vector/Persistent.hs
@@ -10,6 +10,10 @@
 -- bounds given are mostly O(1), but only if you are willing to accept
 -- that the tree cannot have height greater than 7 on 32 bit systems
 -- and maybe 8 on 64 bit systems.
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{- options_ghc -ddump-simpl #-}
+
 module Data.Vector.Persistent (
   Vector,
   -- * Construction
@@ -17,6 +21,7 @@ module Data.Vector.Persistent (
   singleton,
   snoc,
   fromList,
+  append,
   -- * Queries
   null,
   length,
@@ -48,7 +53,7 @@ import Prelude hiding
 
 import qualified Control.Applicative as Ap
 import Control.DeepSeq
-import Data.Bits
+import Data.Bits hiding (shiftR, shiftL)
 import qualified Data.Foldable as F
 import qualified Data.List as L
 import Data.Semigroup as Sem
@@ -56,14 +61,16 @@ import qualified Data.Traversable as T
 
 import Data.Vector.Persistent.Array ( Array )
 import qualified Data.Vector.Persistent.Array as A
+#if !MIN_VERSION_base(4,8,0)
+import Data.Word (Word)
+#endif
 
 -- Note: using Int here doesn't give the full range of 32 bits on a 32
 -- bit machine (it is fine on 64)
 
 -- | Persistent vectors based on array mapped tries
 data Vector a
-  = EmptyVector
-  | RootNode
+  = RootNode
      { vecSize :: !Int
      , vecShift :: !Int
      , vecTail :: ![a]
@@ -96,6 +103,14 @@ instance F.Foldable Vector where
   foldMap = T.foldMapDefault
   foldr = foldr
   foldl = foldl
+#if MIN_VERSION_base(4,6,0)
+  foldr' = foldr'
+  foldl' = foldl'
+#endif
+#if MIN_VERSION_base(4,8,0)
+  length = length
+  null = null
+#endif
 
 instance Functor Vector where
   fmap = map
@@ -117,12 +132,18 @@ instance NFData a => NFData (Vector a) where
 instance NFData a => NFData (Vector_ a) where
   rnf = pvRnf_
 
+shiftR :: Int -> Int -> Int
+{-# INLINE shiftR #-}
+shiftR = unsafeShiftR
+
+shiftL :: Int -> Int -> Int
+{-# INLINE shiftL #-}
+shiftL = unsafeShiftL
+
 {-# INLINABLE pvEq #-}
 pvEq :: Eq a => Vector a -> Vector a -> Bool
-pvEq EmptyVector EmptyVector = True
 pvEq (RootNode sz1 sh1 t1 v1) (RootNode sz2 sh2 t2 v2) =
-  sz1 == sz2 && sh1 == sh2 && t1 == t2 && v1 == v2
-pvEq _ _ = False
+  sz1 == sz2 && (sz1 == 0 || (sh1 == sh2 && t1 == t2 && v1 == v2))
 
 {-# INLINABLE pvEq_ #-}
 pvEq_ :: Eq a => Vector_ a -> Vector_ a -> Bool
@@ -132,11 +153,8 @@ pvEq_ _ _ = False
 
 {-# INLINABLE pvCompare #-}
 pvCompare :: Ord a => Vector a -> Vector a -> Ordering
-pvCompare EmptyVector EmptyVector = EQ
 pvCompare (RootNode sz1 _ t1 v1) (RootNode sz2 _ t2 v2) =
-  compare sz1 sz2 <> compare v1 v2 <> compare t1 t2
-pvCompare EmptyVector _ = LT
-pvCompare _ EmptyVector = GT
+  compare sz1 sz2 <> if sz1 == 0 then EQ else compare v1 v2 <> compare t1 t2
 
 {-# INLINABLE pvCompare_ #-}
 pvCompare_ :: Ord a => Vector_ a -> Vector_ a -> Ordering
@@ -151,7 +169,6 @@ pvCompare_ (InternalNode _) (DataNode _) = GT
 map :: (a -> b) -> Vector a -> Vector b
 map f = go
   where
-    go EmptyVector = EmptyVector
     go (RootNode sz sh t v) =
       let t' = L.map f t
           v' = A.map go_ v
@@ -160,28 +177,37 @@ map f = go
     go_ (DataNode v) = DataNode (A.map f v)
     go_ (InternalNode v) = InternalNode (A.map go_ v)
 
-{-# INLINABLE foldr #-}
+{-# INLINE foldr #-}
 -- | \( O(n) \) Right fold over the vector
 foldr :: (a -> b -> b) -> b -> Vector a -> b
 foldr f = go
   where
-    go seed EmptyVector = seed
     go seed (RootNode _ _ t as) = {-# SCC "gorRootNode" #-}
-      let tseed = F.foldl (flip f) seed t
+      let tseed = F.foldr f seed (L.reverse t)
       in A.foldr go_ tseed as
     go_ (DataNode a) seed = {-# SCC "gorDataNode" #-} A.foldr f seed a
     go_ (InternalNode as) seed = {-# SCC "gorInternalNode" #-}
       A.foldr go_ seed as
 
+-- | \( O(n) \) Strict right fold over the vector.
+--
+-- Note: Strict in the initial accumulator value.
 foldr' :: (a -> b -> b) -> b -> Vector a -> b
-foldr' = F.foldr'
+{-# INLINE foldr' #-}
+foldr' f = go
+  where
+    go !seed (RootNode _ _ t as) = {-# SCC "gorRootNode" #-}
+      let !tseed = F.foldl' (flip f) seed t
+      in A.foldr' go_ tseed as
+    go_ (DataNode a) !seed = {-# SCC "gorDataNode" #-} A.foldr' f seed a
+    go_ (InternalNode as) !seed = {-# SCC "gorInternalNode" #-}
+      A.foldr' go_ seed as
 
-{-# INLINABLE foldl #-}
--- | \( O(n) \) Left fold over the vector
+-- | \( O(n) \) Left fold over the vector.
 foldl :: (b -> a -> b) -> b -> Vector a -> b
+{-# INLINE foldl #-}
 foldl f = go
   where
-    go seed EmptyVector = seed
     go seed (RootNode _ _ t as) =
       let rseed = A.foldl go_ seed as
       in F.foldr (flip f) rseed t
@@ -190,29 +216,38 @@ foldl f = go
     go_ seed (InternalNode as) =
       A.foldl go_ seed as
 
--- | \( O(n) \) Strict left fold over the vector
+-- | \( O(n) \) Strict left fold over the vector.
+--
+-- Note: Strict in the initial accumulator value.
 foldl' :: (b -> a -> b) -> b -> Vector a -> b
-foldl' = F.foldl'
+{-# INLINE foldl' #-}
+foldl' f = go
+  where
+    go !seed (RootNode _ _ t as) =
+      let !rseed = A.foldl' go_ seed as
+      in F.foldl' f rseed (L.reverse t)
+    go_ !seed (DataNode a) = {-# SCC "golDataNode" #-} A.foldl' f seed a
+    go_ !seed (InternalNode as) =
+      A.foldl' go_ seed as
 
-{-# INLINABLE pvTraverse #-}
+{-# INLINE pvTraverse #-}
 pvTraverse :: Ap.Applicative f => (a -> f b) -> Vector a -> f (Vector b)
 pvTraverse f = go
   where
-    go EmptyVector = Ap.pure EmptyVector
-    go (RootNode sz sh t as) =
-      Ap.liftA2 (RootNode sz sh) (T.traverse f t) (A.traverseArray go_ as)
+    go (RootNode sz sh t as)
+      | sz == 0 = Ap.pure empty
+      | otherwise = Ap.liftA2 (RootNode sz sh) (T.traverse f t) (A.traverseArray go_ as)
     go_ (DataNode a) = DataNode Ap.<$> A.traverseArray f a
     go_ (InternalNode as) = InternalNode Ap.<$> A.traverseArray go_ as
 
-{-# INLINABLE append #-}
 append :: Vector a -> Vector a -> Vector a
-append EmptyVector v = v
-append v EmptyVector = v
+append v1 v2
+  | null v1 = v2
+  | null v2 = v1
 append v1 v2 = F.foldl' snoc v1 v2
 
 {-# INLINABLE pvRnf #-}
 pvRnf :: NFData a => Vector a -> ()
-pvRnf EmptyVector = ()
 pvRnf (RootNode _ _ t as) = rnf as `seq` rnf t
 
 {-# INLINABLE pvRnf_ #-}
@@ -222,22 +257,24 @@ pvRnf_ (InternalNode a) = rnf a
 
 -- | \( O(1) \) The empty vector.
 empty :: Vector a
-empty = EmptyVector
+empty = RootNode 0 5 [] A.empty
 
 -- | \( O(1) \) Test to see if the vector is empty.
 null :: Vector a -> Bool
-null EmptyVector = True
-null _ = False
+null xs = length xs == 0
 
 -- | \( O(1) \) Get the length of the vector.
 length :: Vector a -> Int
-length EmptyVector = 0
 length RootNode { vecSize = s } = s
 
 -- | \( O(1) \) Bounds-checked indexing into a vector.
 index :: Vector a -> Int -> Maybe a
 index v ix
-  | length v > ix = unsafeIndexA v ix
+  -- Check if the index is valid. This funny business uses a single test to
+  -- determine whether ix is too small (negative) or too large (at least the
+  -- length of the vector).
+  | (fromIntegral ix :: Word) < fromIntegral (length v)
+  = unsafeIndexA v ix
   | otherwise = Nothing
 
 -- Index into a list from the rear.
@@ -287,7 +324,9 @@ unsafeIndex vec ix
 -- return nonsense values.
 unsafeIndexA :: Ap.Applicative f => Vector a -> Int -> f a
 {-# INLINABLE unsafeIndexA #-}
-unsafeIndexA vec ix | (# a #) <- unsafeIndex# vec ix = Ap.pure a
+unsafeIndexA vec ix
+  | (# a #) <- unsafeIndex# vec ix
+  = Ap.pure a
 
 -- | \( O(1) \) Unchecked indexing into a vector.
 --
@@ -337,7 +376,7 @@ singleton elt =
 
 -- | A helper to copy an array and add an element to the end.
 arraySnoc :: Array a -> a -> Array a
-arraySnoc a elt = A.run $ do
+arraySnoc !a elt = A.run $ do
   let alen = A.length a
   a' <- A.new_ (1 + alen)
   A.copy a 0 a' 0 alen
@@ -346,10 +385,23 @@ arraySnoc a elt = A.run $ do
 
 -- | \( O(1) \) Append an element to the end of the vector.
 snoc :: Vector a -> a -> Vector a
-snoc EmptyVector elt = singleton elt
-snoc v@RootNode { vecSize = sz, vecShift = sh, vecTail = t } elt
-  -- Room in tail
+-- We break this up into two pieces. We let the common case inline:
+-- that is the case of a nonempty vector with room in its tail.
+-- The case of an empty vector isn't common enough to bother inlining,
+-- and the case of a full tail is expensive anyway, so there's nothing
+-- to be gained by inlining. The remaining question: do we actually
+-- benefit from letting *any* of this inline? To be determined, but my
+-- guess is a strong maybe.
+snoc v@RootNode { vecSize = sz, vecTail = t } elt
+  -- Room in tail, and vector non-empty
   | sz .&. 0x1f /= 0 = v { vecTail = elt : t, vecSize = sz + 1 }
+  | otherwise = snocMain v elt
+
+snocMain :: Vector a -> a -> Vector a
+{-# NOINLINE snocMain #-}
+snocMain v elt
+  | null v = singleton elt
+snocMain v@RootNode { vecSize = sz, vecShift = sh, vecTail = t } elt
   -- Overflow current root
   | sz `shiftR` 5 > 1 `shiftL` sh =
     RootNode { vecSize = sz + 1
@@ -370,9 +422,9 @@ snoc v@RootNode { vecSize = sz, vecShift = sh, vecTail = t } elt
 -- | A recursive helper for 'snoc'.  This finds the place to add new
 -- elements.
 pushTail :: Int -> [a] -> Int -> Array (Vector_ a) -> Array (Vector_ a)
-pushTail cnt t = go
+pushTail !cnt t !foo !bar = go foo bar
   where
-    go level parent
+    go !level !parent
       | level == 5 = arraySnoc parent (DataNode (A.fromListRev 32 t))
       | subIdx < A.length parent =
         let nextVec = A.index parent subIdx
@@ -389,36 +441,29 @@ newPath level t
   | level == 0 = DataNode (A.fromListRev 32 t)
   | otherwise = InternalNode $ A.fromList 1 $ [newPath (level - 5) t]
 
+-- | Update a single element at @ix@ with new value @elt@.
+updateList :: Int -> a -> [a] -> [a]
+-- We do this pretty strictly to avoid building up thunks in the tail
+-- and to release the replaced value promptly.
+updateList !_ _ [] = []
+updateList 0 x (_ : ys) = x : ys
+updateList n x (y : ys) = (y :) $! updateList (n - 1) x ys
+
 -- | \( O(1) \) Update a single element at @ix@ with new value @elt@ in @v@.
 --
 -- > update ix elt v
 update :: Int -> a -> Vector a -> Vector a
-update ix elt = (// [(ix, elt)])
-
--- | \( O(n) \) Bulk update.
---
--- > v // updates
---
--- For each @(index, element)@ pair in @updates@, modify @v@ such that
--- the @index@th position of @v@ is @element@.
--- Indices in @updates@ that are not in @v@ are ignored
-(//) :: Vector a -> [(Int, a)] -> Vector a
-(//)  = L.foldr replaceElement
-
-replaceElement :: (Int, a) -> Vector a -> Vector a
-replaceElement _ EmptyVector = EmptyVector
-replaceElement (ix, elt) v@(RootNode { vecSize = sz, vecShift = sh, vecTail = t })
-  -- Invalid index
-  | sz <= ix || ix < 0 = v
-  -- Item is in tail,
-  | ix >= toff =
+update ix elt v@(RootNode { vecSize = sz, vecShift = sh, vecTail = t })
+  -- Invalid index. This funny business uses a single test to determine whether
+  -- ix is too small (negative) or too large (at least sz).
+  | (fromIntegral ix :: Word) >= fromIntegral sz = v
+  -- Item is in tail
+  | ix >= tailOffset v =
     let tix = sz - 1 - ix
-        (keepHead, _:keepTail) = L.splitAt tix t
-    in v { vecTail = keepHead ++ (elt : keepTail) }
+    in v { vecTail = updateList tix elt t}
   -- Otherwise the item to be replaced is in the tree
   | otherwise = v { intVecPtrs = go sh (intVecPtrs v) }
   where
-    toff = tailOffset v
     go level vec
       -- At the data level, modify the vector and start propagating it up
       | level == 5 =
@@ -433,23 +478,38 @@ replaceElement (ix, elt) v@(RootNode { vecSize = sz, vecShift = sh, vecTail = t 
         vix = (ix `shiftR` level) .&. 0x1f
         vec' = A.index vec vix
 
-tailOffset :: Vector a -> Int
-tailOffset EmptyVector = 0
-tailOffset v
-  | len < 32 = 0
-  | otherwise = (len - 1) `shiftR` 5 `shiftL` 5
+-- | \( O(n) \) Bulk update.
+--
+-- > v // updates
+--
+-- For each @(index, element)@ pair in @updates@, modify @v@ such that
+-- the @index@th position of @v@ is @element@.
+-- Indices in @updates@ that are not in @v@ are ignored. The updates are
+-- applied in order, so the last one at each index takes effegct.
+(//) :: Vector a -> [(Int, a)] -> Vector a
+-- Note: we fully apply foldl' to get everything to unbox.
+(//) vec = L.foldl' replaceElement vec
   where
-    len = length v
+    replaceElement v (ix, a) = update ix a v
+
+-- | The index of the first element of the tail of the vector (that is, the
+-- *last* element of the list representing the tail). This is also the number
+-- of elements stored in the array tree.
+--
+-- Caution: Only gives a sensible result if the vector is nonempty.
+tailOffset :: Vector a -> Int
+tailOffset v = (length v - 1) .&. ((-1) `shiftL` 5)
 
 -- | \( O(n) \) Reverse a vector
 reverse :: Vector a -> Vector a
-reverse = fromList . F.foldl' (flip (:)) []
+{-# NOINLINE reverse #-}
+reverse = foldr' (flip snoc) empty
 
 -- | \( O(n) \) Filter according to the predicate.
 filter :: (a -> Bool) -> Vector a -> Vector a
-filter p = F.foldl' go empty
+filter p = \ !vec -> foldl' go empty vec
   where
-    go acc e = if p e then snoc acc e else acc
+    go !acc e = if p e then snoc acc e else acc
 
 -- | \( O(n) \) Return the elements that do and do not obey the predicate
 partition :: (a -> Bool) -> Vector a -> (Vector a, Vector a)
@@ -459,7 +519,7 @@ partition p v0 = case F.foldl' go (TwoVec empty empty) v0 of
     go (TwoVec atrue afalse) e =
       if p e then TwoVec (snoc atrue e) afalse else TwoVec atrue (snoc afalse e)
 
-data TwoVec a = TwoVec !(Vector a) !(Vector a)
+data TwoVec a = TwoVec {-# UNPACK #-} !(Vector a) {-# UNPACK #-} !(Vector a)
 
 -- | \( O(n) \) Construct a vector from a list. (O(n))
 fromList :: [a] -> Vector a

--- a/tests/pvTests.hs
+++ b/tests/pvTests.hs
@@ -31,7 +31,7 @@ sizedList sz = do
 
 inputList :: Int -> Gen InputList
 inputList sz = do
-  len <- chooseInt (1, max 1 (sz)) -- Tune this
+  len <- chooseInt (0, max 1 sz)
   InputList Ap.<$> vector len
 
 tests :: [Test]


### PR DESCRIPTION
* Remove the empty constructor, allowing GHC to unbox vectors.

* Make strict folds a bit stricter and force them to inline, which lets
  GHC optimize `filter`, `partition`, and `reverse` to avoid allocating
  a fresh root node on every `snoc`. The folds now match *list* folds
  rather than the default `Foldable` definitions. The inlining isn't free,
  but it seems pretty important. Also use `List.reverse` just a tad in
  `foldl'` and `foldr` to avoid likely-unproductive muck in the Core. 

* Add `Foldable` method definitions.

* Use "unsafe" shifts.

* Break up `snoc` so the common case can inline.

* Make `index` catch negative indices as well as ones that are
  too large.

* Define `//` in terms of `update`, rather than the other way around.

* Define `reverse` using `foldr'` rather than working via a list.

* Unpack the vectors in the intermediate result of `partition`.

* Test unsafe indexing much more aggressively by testing all indices
  into the generated vector instead of just one.

* Let the `Arbitrary` instances produce small vectors more easily;
  we can then set up CI to run the test suite with multiple size settings to
  catch any issues that might arise with small or large vectors.