### PR TITLE
Make traverse go in order

### DIFF
--- a/persistent-vector.cabal
+++ b/persistent-vector.cabal
@@ -40,7 +40,7 @@ library
   default-language: Haskell2010
   exposed-modules: Data.Vector.Persistent
   other-modules: Data.Vector.Persistent.Array
-  build-depends: base ==4.*, deepseq
+  build-depends: base ==4.*, deepseq, transformers
   if !impl(ghc >= 8.0)
     build-depends: semigroups == 0.18.*
   hs-source-dirs: src

--- a/src/Data/Vector/Persistent.hs
+++ b/src/Data/Vector/Persistent.hs
@@ -58,6 +58,7 @@ import qualified Data.Foldable as F
 import qualified Data.List as L
 import Data.Semigroup as Sem
 import qualified Data.Traversable as T
+import Control.Applicative.Backwards
 
 import Data.Vector.Persistent.Array ( Array )
 import qualified Data.Vector.Persistent.Array as A
@@ -236,7 +237,7 @@ pvTraverse f = go
   where
     go (RootNode sz sh t as)
       | sz == 0 = Ap.pure empty
-      | otherwise = Ap.liftA2 (RootNode sz sh) (T.traverse f t) (A.traverseArray go_ as)
+      | otherwise = Ap.liftA2 (\as' t' -> RootNode sz sh t' as') (A.traverseArray go_ as) (forwards $ T.traverse (Backwards . f) t)
     go_ (DataNode a) = DataNode Ap.<$> A.traverseArray f a
     go_ (InternalNode as) = InternalNode Ap.<$> A.traverseArray go_ as
 

--- a/tests/pvTests.hs
+++ b/tests/pvTests.hs
@@ -8,6 +8,7 @@ import qualified Data.Foldable as F
 import Data.Monoid
 import qualified Data.List as L
 import qualified Control.Applicative as Ap
+import qualified Data.Traversable as T
 
 --import Data.Vector.Persistent ( Vector )
 import qualified Data.Vector.Persistent as V
@@ -39,6 +40,7 @@ tests = [ testProperty "toListFromListIdent" prop_toListFromListIdentity
         , testProperty "fmap" prop_map
         , testProperty "foldrWorks" prop_foldrWorks
         , testProperty "foldlWorks" prop_foldlWorks
+        , testProperty "traverseWorks" prop_traverseWorks
         , testProperty "updateWorks" prop_updateWorks
         , testProperty "indexingWorks" prop_indexingWorks
         , testProperty "mappendWorks" prop_mappendWorks
@@ -96,3 +98,9 @@ prop_eqWorks_equal (InputList il) =
 prop_eqWorks :: InputList -> InputList -> Bool
 prop_eqWorks (InputList il1) (InputList il2) =
   (V.fromList il1 == V.fromList il2) == (il1 == il2)
+
+prop_traverseWorks :: InputList -> Bool
+prop_traverseWorks (InputList il) =
+  fmap F.toList (T.traverse go (V.fromList il)) == T.traverse go il
+  where
+    go a = ([a], a)


### PR DESCRIPTION
Previously, the tail was traversed first, from right to left,
then the tree, from left to right. Make it traverse the whole
thing in order.