### PR TITLE
Restore the slicing API

### DIFF
--- a/.github/workflows/ci-matrix.yml
+++ b/.github/workflows/ci-matrix.yml
@@ -16,6 +16,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         ghc: ['7.10', '8.0', '8.2', '8.4', '8.6', '8.8', '8.10']
         cabal: ['3.2.0.0']

--- a/src/Data/Vector/Persistent.hs
+++ b/src/Data/Vector/Persistent.hs
@@ -30,6 +30,12 @@ module Data.Vector.Persistent (
   unsafeIndex,
   unsafeIndexA,
   unsafeIndex#,
+  take,
+  drop,
+  splitAt,
+  slice,
+  -- ** Slicing Storage Management
+  shrink,
   -- * Modification
   update,
   (//),
@@ -42,6 +48,8 @@ module Data.Vector.Persistent (
   map,
   reverse,
   -- * Searches
+  takeWhile,
+  dropWhile,
   filter,
   partition
   ) where
@@ -49,7 +57,8 @@ module Data.Vector.Persistent (
 import Prelude hiding
   ( null, length, tail, take
   , drop, map, foldr, foldl
-  , reverse, splitAt, filter )
+  , reverse, splitAt, filter
+  , takeWhile, dropWhile )
 
 import qualified Control.Applicative as Ap
 import Control.DeepSeq
@@ -527,3 +536,38 @@ data TwoVec a = TwoVec {-# UNPACK #-} !(Vector a) {-# UNPACK #-} !(Vector a)
 -- | \( O(n) \) Construct a vector from a list. (O(n))
 fromList :: [a] -> Vector a
 fromList = F.foldl' snoc empty
+
+-- | O(n) Take @n@ elements starting from the start of the 'Vector'
+take :: Int -> Vector a -> Vector a
+take n v = fromList (L.take n (F.toList v))
+
+-- | O(n) Drop @n@ elements starting from the start of the 'Vector'
+drop :: Int -> Vector a -> Vector a
+drop n v = fromList (L.drop n (F.toList v))
+
+-- | O(n) Split the vector into two at the given index
+splitAt :: Int -> Vector a -> (Vector a, Vector a)
+splitAt idx v = (take idx v, drop idx v)
+
+-- | O(n) Return a slice of @v@ of length @length@ starting at index
+-- @start@.  The returned vector may have fewer than @length@ elements
+-- if the bounds are off on either side (the start is negative or
+-- length takes it past the end).
+--
+-- A slice of negative or zero length is the empty vector.
+--
+-- > slice start length v
+slice :: Int -> Int -> Vector a -> Vector a
+slice start len v = fromList (L.take len (L.drop start (F.toList v)))
+
+-- | O(1) Drop any unused space in the vector
+--
+-- NOTE: This is currently the identity
+shrink :: Vector a -> Vector a
+shrink = id
+
+takeWhile :: (a -> Bool) -> Vector a -> Vector a
+takeWhile p = fromList . L.takeWhile p . F.toList
+
+dropWhile :: (a -> Bool) -> Vector a -> Vector a
+dropWhile p = fromList . L.dropWhile p . F.toList

--- a/tests/pvTests.hs
+++ b/tests/pvTests.hs
@@ -6,9 +6,7 @@ import Test.Framework.Providers.QuickCheck2 ( testProperty )
 import Test.QuickCheck
 
 import qualified Data.Foldable as F
-#if !MIN_VERSION_base(4,9,0)
-import Data.Monoid
-#endif
+import qualified Data.Monoid as DM
 import qualified Data.List as L
 import qualified Control.Applicative as Ap
 import qualified Data.Traversable as T
@@ -103,7 +101,7 @@ prop_indexingWorks (SizedList il sz) =
 
 prop_mappendWorks :: (InputList, InputList) -> Bool
 prop_mappendWorks (InputList il1, InputList il2) =
-  (il1 `mappend` il2) == F.toList (V.fromList il1 <> V.fromList il2)
+  (il1 `DM.mappend` il2) == F.toList (V.fromList il1 `DM.mappend` V.fromList il2)
 
 prop_eqWorks_equal :: InputList -> Bool
 prop_eqWorks_equal (InputList il) =


### PR DESCRIPTION
The implementations are very inefficient because they go through lists, but at
least they are correct. This lets us retain backwards compatibility, and will
give us the opportunity to add a more efficient implementation of slicing later.

Closes #13
Fixes #3